### PR TITLE
Patch 06

### DIFF
--- a/geosparql/illustration/query01.srx
+++ b/geosparql/illustration/query01.srx
@@ -4,10 +4,10 @@
 </head>
 <results>
 <result>
-<binding name='f'><uri>http://somewhere/ApplicationSchema#B</uri></binding>
+<binding name='f'><uri>http://example.org/ApplicationSchema#B</uri></binding>
 </result>
 <result>
-<binding name='f'><uri>http://somewhere/ApplicationSchema#F</uri></binding>
+<binding name='f'><uri>http://example.org/ApplicationSchema#F</uri></binding>
 </result>
 </results>
 </sparql>

--- a/geosparql/illustration/query02.srx
+++ b/geosparql/illustration/query02.srx
@@ -4,7 +4,7 @@
 </head>
 <results>
 <result>
-<binding name='f'><uri>http://somewhere/ApplicationSchema#D</uri></binding>
+<binding name='f'><uri>http://example.org/ApplicationSchema#D</uri></binding>
 </result>
 </results>
 </sparql>

--- a/geosparql/illustration/query03.srx
+++ b/geosparql/illustration/query03.srx
@@ -4,7 +4,7 @@
 </head>
 <results>
 <result>
-<binding name='f'><uri>http://somewhere/ApplicationSchema#C</uri></binding>
+<binding name='f'><uri>http://example.org/ApplicationSchema#C</uri></binding>
 </result>
 </results>
 </sparql>

--- a/geosparql/illustration/query04.srx
+++ b/geosparql/illustration/query04.srx
@@ -4,13 +4,13 @@
 </head>
 <results>
 <result>
-<binding name='f'><uri>http://somewhere/ApplicationSchema#A</uri></binding>
+<binding name='f'><uri>http://example.org/ApplicationSchema#A</uri></binding>
 </result>
 <result>
-<binding name='f'><uri>http://somewhere/ApplicationSchema#D</uri></binding>
+<binding name='f'><uri>http://example.org/ApplicationSchema#D</uri></binding>
 </result>
 <result>
-<binding name='f'><uri>http://somewhere/ApplicationSchema#E</uri></binding>
+<binding name='f'><uri>http://example.org/ApplicationSchema#E</uri></binding>
 </result>
 </results>
 </sparql>

--- a/geosparql/illustration/query05.srx
+++ b/geosparql/illustration/query05.srx
@@ -4,16 +4,16 @@
 </head>
 <results>
 <result>
-<binding name='f'><uri>http://somewhere/ApplicationSchema#D</uri></binding>
+<binding name='f'><uri>http://example.org/ApplicationSchema#D</uri></binding>
 </result>
 <result>
-<binding name='f'><uri>http://somewhere/ApplicationSchema#DExactGeom</uri></binding>
+<binding name='f'><uri>http://example.org/ApplicationSchema#DExactGeom</uri></binding>
 </result>
 <result>
-<binding name='f'><uri>http://somewhere/ApplicationSchema#E</uri></binding>
+<binding name='f'><uri>http://example.org/ApplicationSchema#E</uri></binding>
 </result>
 <result>
-<binding name='f'><uri>http://somewhere/ApplicationSchema#EExactGeom</uri></binding>
+<binding name='f'><uri>http://example.org/ApplicationSchema#EExactGeom</uri></binding>
 </result>
 </results>
 </sparql>

--- a/geosparql/illustration/query05_detail.srx
+++ b/geosparql/illustration/query05_detail.srx
@@ -4,16 +4,16 @@
 </head>
 <results>
 <result>
-<binding name='f'><uri>http://somewhere/ApplicationSchema#D</uri></binding>
+<binding name='f'><uri>http://example.org/ApplicationSchema#D</uri></binding>
 </result>
 <result>
-<binding name='f'><uri>http://somewhere/ApplicationSchema#DExactGeom</uri></binding>
+<binding name='f'><uri>http://example.org/ApplicationSchema#DExactGeom</uri></binding>
 </result>
 <result>
-<binding name='f'><uri>http://somewhere/ApplicationSchema#E</uri></binding>
+<binding name='f'><uri>http://example.org/ApplicationSchema#E</uri></binding>
 </result>
 <result>
-<binding name='f'><uri>http://somewhere/ApplicationSchema#EExactGeom</uri></binding>
+<binding name='f'><uri>http://example.org/ApplicationSchema#EExactGeom</uri></binding>
 </result>
 </results>
 </sparql>


### PR DESCRIPTION
All six expected answers for the GeoSPARQL subtest had incorrect entity URIs. For instance:

- Incorrect: `<http://somewhere/ApplicationSchema#B>`
- Correct: `<http://example.org/ApplicationSchema#B>`

This is due to the usage of `<http://example.org/ApplicationSchema#>` as a prefix in the subtest dataset (`example.rdf`) and in all six GeoSPARQL queries.

This patch makes corrections to all GeoSPARQL expected answers.